### PR TITLE
Update README.md

### DIFF
--- a/04-Operator/README.md
+++ b/04-Operator/README.md
@@ -64,7 +64,7 @@
 
 ```jsx
 // NaN은 자신과 일치하지 않는 유일한 값이다.
-NaN === NaNl; // false
+NaN === NaN; // false
 
 // NaN 인지 조사가 필요시 -> 빌트인 함수 "isNaN(value)"을 사용
 isNaN(NaN); // true


### PR DESCRIPTION
1. 오타 수정 (67번 줄) "> 💡 일치 연산자(===)라 해도 `NaN` 에 대해서는 주의할 것" 문단 NaN === NaN1 > NaN === NaN 으로 수정